### PR TITLE
ignore login errors if we are already logged in

### DIFF
--- a/tasks/connect_to_target.yml
+++ b/tasks/connect_to_target.yml
@@ -19,3 +19,5 @@
     --portal {{ (item.path|basename).split(',')[1] }}:{{ (item.path|basename).split(',')[2] }}
   with_items:
     - "{{ find_result['files'] }}"
+  register: login_result
+  failed_when: 'login_result.rc != 0 and not "1 session requested, but 1 already present." in login_result.stderr'

--- a/tasks/connect_to_target.yml
+++ b/tasks/connect_to_target.yml
@@ -21,3 +21,4 @@
     - "{{ find_result['files'] }}"
   register: login_result
   failed_when: 'login_result.rc != 0 and not "1 session requested, but 1 already present." in login_result.stderr'
+  changed_when: '"1 session requested, but 1 already present." not in login_result.stderr'

--- a/tasks/connect_to_target.yml
+++ b/tasks/connect_to_target.yml
@@ -21,4 +21,6 @@
     - "{{ find_result['files'] }}"
   register: login_result
   failed_when: 'login_result.rc != 0 and not "1 session requested, but 1 already present." in login_result.stderr'
+  # iscsiadm on SUSE/openSUSE 15.x reports if there is already an existing session
+  # in this case we set the task as 'unchanged'
   changed_when: '"1 session requested, but 1 already present." not in login_result.stderr'


### PR DESCRIPTION
If the string '1 session requested, but 1 already present.' is found in the stderr output then the login fails as we are already logged in...

In case this string is present, we ignore the errors and show the task as unchanged (to simulate idempotency).