### PR TITLE
add task to change to automatic login instead of manual (on SUSE/openSUSE only)

### DIFF
--- a/tasks/connect_to_target.yml
+++ b/tasks/connect_to_target.yml
@@ -19,3 +19,12 @@
     --portal {{ (item.path|basename).split(',')[1] }}:{{ (item.path|basename).split(',')[2] }}
   with_items:
     - "{{ find_result['files'] }}"
+
+- name: Change to automatic startup on *SUSE
+  command: >-
+    iscsiadm --mode node --targetname {{ (item.path|basename).split(',')[0] }}
+    --portal {{ (item.path|basename).split(',')[1] }}:{{ (item.path|basename).split(',')[2] }}
+    -o update -n node.conn[0].startup -v automatic -n node.startup -v automatic
+  with_items:
+    - "{{ find_result['files'] }}"
+  when: 'ansible_distribution == "SLES" or ansible_distribution == "openSUSE Leap"'


### PR DESCRIPTION
fixes #4 hopefully

On SUSE/openSUSE the iscsi.service only logs in for connections that have the startup set to `automatic`. Adding another iscsiadm command that modifies the startup to be automatic changes that.