### PR TITLE
set node.startup to 'automatic' in /etc/iscsi/iscsid.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,12 @@
     enabled: true
     state: 'started'
 
+- name: Set startup to automatic in /etc/iscsi/iscid.conf
+  lineinfile:
+    path: /etc/iscsi/iscsid.conf
+    regex: '^node\.startup\ =\ manual'
+    line: node.startup = automatic
+
 - name: Collect facts about installed iSCSI initiator
   iscsiadm_facts:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,12 @@
 
 - name: Set startup to automatic in /etc/iscsi/iscid.conf
   lineinfile:
-    path: /etc/iscsi/iscsid.conf
+    path: '/etc/iscsi/iscsid.conf'
     regex: '^node\.startup\ =\ manual'
-    line: node.startup = automatic
+    line: 'node.startup = automatic'
+    owner: 'root'
+    group: 'root'
+    mode: '0600'
 
 - name: Collect facts about installed iSCSI initiator
   iscsiadm_facts:


### PR DESCRIPTION
alternative solution for #4 

Tested successfully on:
- CentOS7
- CentOS8
- openSUSE Leap 15.2
- SLES15.1